### PR TITLE
Fix agent navigation null issue by initializing heuristics for safe access

### DIFF
--- a/src/main/java/pedsim/core/agents/Agent.java
+++ b/src/main/java/pedsim/core/agents/Agent.java
@@ -274,7 +274,9 @@ public class Agent implements Steppable {
 	 * Plans the route for the agent.
 	 */
 	protected void planRoute() {
-		Heuristics heuristics = new Heuristics(this);
+		// Initialise and store the agent's heuristics so that other components
+		// (e.g. landmark-based navigation) can safely access them via getHeuristics().
+		heuristics = new Heuristics(this);
 		heuristics.defineHeuristic(originNode, destinationNode, false);
 		RoutePlanner planner = new RoutePlanner(originNode, destinationNode, this);
 		setRoute(planner.definePath());

--- a/src/main/java/pedsim/core/routing/elements/LandmarkNavigation.java
+++ b/src/main/java/pedsim/core/routing/elements/LandmarkNavigation.java
@@ -38,7 +38,12 @@ public class LandmarkNavigation {
 	private static final double DISTANCE_GAIN_WEIGHT_REGION = 0.50;
 
 	protected void idntifyAgentLocalLandmarks() {
-
+		
+		// Use local landmarks only when the agent's heuristics are available
+		// and local-landmark-based navigation is actually active for this agent.
+		if (agent == null || agent.getHeuristics() == null || !agent.getProperties().isUsingLocalLandmarks()) {
+			return;
+		}
 		double localLandmarkThreshold = agent.getHeuristics().getLocalLandmarksThreshold();
 		agent.getCognitiveMap().findKnownLocalLandmarks(localLandmarkThreshold);
 	}


### PR DESCRIPTION
Added checks for local landmark usage in LandmarkNavigation. Code was failing as landmark logic being used even when no landmark setup was effectively available for Torino.