### PR TITLE
Timepars release update

### DIFF
--- a/src/main/java/pedsim/core/agents/Agent.java
+++ b/src/main/java/pedsim/core/agents/Agent.java
@@ -274,7 +274,9 @@ public class Agent implements Steppable {
 	 * Plans the route for the agent.
 	 */
 	protected void planRoute() {
-		Heuristics heuristics = new Heuristics(this);
+		// Initialise and store the agent's heuristics so that other components
+		// (e.g. landmark-based navigation) can safely access them via getHeuristics().
+		heuristics = new Heuristics(this);
 		heuristics.defineHeuristic(originNode, destinationNode, false);
 		RoutePlanner planner = new RoutePlanner(originNode, destinationNode, this);
 		setRoute(planner.definePath());

--- a/src/main/java/pedsim/core/engine/AgentReleaseManager.java
+++ b/src/main/java/pedsim/core/engine/AgentReleaseManager.java
@@ -1,5 +1,9 @@
 package pedsim.core.engine;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -29,6 +33,8 @@ public class AgentReleaseManager {
   protected double metersToWalkCurrentDay;
   protected double expectedMetersWalkedSoFarToday;
   protected double metersWalkedSoFarToday;
+  private final int dayNumber;
+  private String logFilePath;
 
      /**
    * Constructor for AgentReleaseManager.
@@ -36,12 +42,14 @@ public class AgentReleaseManager {
    * @param state the PedSimCity instance representing the simulation state.
    * @param metersToWalkCurrentDay the current expected walking distance for the day (in meters).
    */
-  public AgentReleaseManager(PedSimCity state, Double metersToWalkCurrentDay) {
+  public AgentReleaseManager(PedSimCity state, Double metersToWalkCurrentDay, int dayNumber) {
     this.state = state;
     this.metersToWalkCurrentDay = metersToWalkCurrentDay;
+    this.dayNumber = dayNumber;
     resetMetersWalkedSoFar();
     expectedMetersWalkedSoFarToday = 0.0;
     metersWalkedSoFarToday = 0.0;
+    initLogFile();
   }
 
   /**
@@ -55,13 +63,13 @@ public class AgentReleaseManager {
     metersWalkedSoFarToday = computeMetersWalkedSoFar();
     double metersToAllocate = (metersToWalkCurrentDay * TimePars.computeTimeStepShare(currentTime));
     double metersAdjusted =
-        (metersToAllocate + (expectedMetersWalkedSoFarToday - metersWalkedSoFarToday)) * 0.5; // to
-                                                                                              // account
-                                                                                              // for
-    // return home
+        (metersToAllocate + (expectedMetersWalkedSoFarToday - metersWalkedSoFarToday)) * 0.5;
+
+    int agentsReleased = 0;
     if (metersAdjusted > 0) {
-      releaseAgentsMeters(metersAdjusted);
+      agentsReleased = releaseAgentsMeters(metersAdjusted);
     }
+    logRelease(steps, metersToAllocate, metersAdjusted, agentsReleased);
     if (currentTime.getMinute() == 0) { // Log walking agents every full hour
       logWalkingAgents();
     }
@@ -76,7 +84,7 @@ public class AgentReleaseManager {
    *
    * @param kmToAllocate the total kilometres to be allocated for the selected agents to walk.
    */
-  private void releaseAgentsMeters(double metersToAllocate) {
+  private int releaseAgentsMeters(double metersToAllocate) {
 
     int agentsExpectedToWalk =
         Math.max(1, (int) (metersToAllocate / RouteChoicePars.avgTripDistance));
@@ -89,6 +97,7 @@ public class AgentReleaseManager {
     for (Agent agent : agentsToRelease) {
       agent.startWalkingAlone();
     }
+    return agentsToRelease.size();
   }
 
   /**
@@ -193,6 +202,34 @@ public class AgentReleaseManager {
    */
   private void resetMetersWalkedSoFar() {
     state.agentsList.forEach(agent -> agent.metersWalkedDay = 0.0);
+  }
+
+  private void initLogFile() {
+    try {
+      File dir = new File("output");
+      if (!dir.exists()) {
+        dir.mkdirs();
+      }
+      logFilePath = "output/agent_release_day_" + dayNumber + ".csv";
+      try (PrintWriter out = new PrintWriter(new FileWriter(logFilePath, false))) {
+        out.println("step,datetime,meters_to_allocate,meters_adjusted,agents_released");
+      }
+    } catch (IOException e) {
+      logger.warning("Could not initialise agent release log file: " + e.getMessage());
+    }
+  }
+
+  private void logRelease(double step, double metersToAllocate, double metersAdjusted,
+      int agentsReleased) {
+    if (logFilePath == null) {
+      return;
+    }
+    try (PrintWriter out = new PrintWriter(new FileWriter(logFilePath, true))) {
+      out.printf("%f,%s,%.4f,%.4f,%d%n", step, currentTime, metersToAllocate, metersAdjusted,
+          agentsReleased);
+    } catch (IOException e) {
+      logger.warning("Could not write agent release log entry: " + e.getMessage());
+    }
   }
 
 }

--- a/src/main/java/pedsim/core/engine/Engine.java
+++ b/src/main/java/pedsim/core/engine/Engine.java
@@ -136,7 +136,7 @@ public class Engine {
   private void handleNewDay() {
     kmCurrentDay = calculateMetersCurrentDay();
     logger.info("---------- Beginning day Nr " + (currentDay + 1));
-    currentDayReleaseManager = new AgentReleaseManager(state, kmCurrentDay);
+    currentDayReleaseManager = new AgentReleaseManager(state, kmCurrentDay, currentDay + 1);
   }
 
   /**

--- a/src/main/java/pedsim/core/parameters/TimePars.java
+++ b/src/main/java/pedsim/core/parameters/TimePars.java
@@ -5,110 +5,94 @@ import java.time.LocalTime;
 
 public class TimePars {
 
-  // in seconds. One step = 20 minutes,
-  public static double STEP_DURATION = 1200; // seconds
-  public static int releaseAgentsEveryMinutes = 20;
-  public static double MINUTE_TO_STEPS;
-  public static double releaseAgentsEverySteps;
-  // public static static double hoursInSteps = 60 * minuteInSteps;
+	// in seconds. One step = 20 minutes,
+	public static double STEP_DURATION = 1200; // seconds
+	public static int releaseAgentsEveryMinutes = 20;
+	public static double MINUTE_TO_STEPS;
+	public static double releaseAgentsEverySteps;
+	// public static static double hoursInSteps = 60 * minuteInSteps;
 
-  // Calculate the total simulation time in seconds for a certain number of days
-  public static int numberOfDays = 7;
-  public static double simulationDurationInSteps;
+	// Calculate the total simulation time in seconds for a certain number of days
+	public static int numberOfDays = 7;
+	public static double simulationDurationInSteps;
 
-  // Define peak hours (adjust these as needed)
-  public static final LocalTime morningPeakStart = LocalTime.of(7, 0);
-  public static final LocalTime morningPeakEnd = LocalTime.of(9, 0);
-  public static final LocalTime eveningPeakStart = LocalTime.of(17, 0);
-  public static final LocalTime eveningPeakEnd = LocalTime.of(19, 0);
-  public static final LocalTime nightStart = LocalTime.of(0, 30);
-  public static final LocalTime nightEnd = LocalTime.of(5, 30);
+	// Gaussian Distribution parameters for pedestrian activity
+	// The total volume across all distributions should roughly sum to 1.0 (100%)
+	public static double morningPeakVolume = 0.2;
+	public static double morningPeakTime = 8.5; // 8:30 AM
+	public static double morningPeakSpread = 1.0; // standard deviation in hours
 
-  // Assume percentage of the population walking during peak hours
-  public static final double peakPercentage = 0.35; // 35%
-  public static final double offPeakPercentage = 0.15; // 15%
-  public static final double nightPercentage = 0.01; // 1%
+	public static double eveningPeakVolume = 0.2;
+	public static double eveningPeakTime = 17.5; // 5:30 PM
+	public static double eveningPeakSpread = 1.0;
 
-  public static int stepsInPeakHours;
-  public static int stepsInOffPeak;
-  public static int stepsAtNight;
+	public static double lunchPeakVolume = 0.05;
+	public static double lunchPeakTime = 13.0; // 1:00 PM
+	public static double lunchPeakSpread = 0.5;
 
-  /**
-   * Defines the simulation mode and sets simulation parameters based on the selected mode. Called
-   * at the beginning of the simulation to configure simulation settings.
-   */
-  public static void setTemporalPars() {
+	public static double nightPeakVolume = 0.3;
+	public static double nightPeakTime = 20.0; // 8:00 PM
+	public static double nightLeftSpread = 1.0; // steep curve in the evening
+	public static double nightRightSpread = 4.0; // long tail into the morning
 
-    MINUTE_TO_STEPS = 60 / STEP_DURATION;
-    releaseAgentsEverySteps = releaseAgentsEveryMinutes * MINUTE_TO_STEPS;
-    simulationDurationInSteps = numberOfDays * 24 * 60 * MINUTE_TO_STEPS; // Days to seconds
-    getStepsInReleaseTimes();
+	public static double backgroundVolume = 0.25; // Base volume uniformly spread over 24 hours
 
-  }
+	/**
+	 * Defines the simulation mode and sets simulation parameters based on the
+	 * selected mode. Called at the beginning of the simulation to configure
+	 * simulation settings.
+	 */
+	public static void setTemporalPars() {
+		MINUTE_TO_STEPS = 60 / STEP_DURATION;
+		releaseAgentsEverySteps = releaseAgentsEveryMinutes * MINUTE_TO_STEPS;
+		simulationDurationInSteps = numberOfDays * 24 * 60 * MINUTE_TO_STEPS; // Days to steps
+	}
 
-  /**
-   * Calculates the number of steps in a given time range based on the step interval. Assumes a step
-   * occurs every 20 minutes.
-   */
+	private static double splitGaussian(double x, double mean, double leftStdDev, double rightStdDev) {
+		double stdDev = (x < mean) ? leftStdDev : rightStdDev;
+		// The normalization factor for split normal is sqrt(2/pi) / (left + right)
+		double normalization = Math.sqrt(2.0 / Math.PI) / (leftStdDev + rightStdDev);
+		return normalization * Math.exp(-0.5 * Math.pow((x - mean) / stdDev, 2));
+	}
 
-  private static void getStepsInReleaseTimes() {
+	private static double wrappedSplitGaussian(double x, double mean, double leftStdDev, double rightStdDev) {
+		// Evaluate at x-24, x, x+24 to handle wrapping around midnight
+		return splitGaussian(x - 24, mean, leftStdDev, rightStdDev)
+				+ splitGaussian(x, mean, leftStdDev, rightStdDev)
+				+ splitGaussian(x + 24, mean, leftStdDev, rightStdDev);
+	}
 
-    stepsInPeakHours = getStepsBetween(morningPeakStart, morningPeakEnd)
-        + getStepsBetween(eveningPeakStart, eveningPeakEnd);
-    stepsInOffPeak = getStepsBetween(nightEnd, morningPeakStart)
-        + getStepsBetween(morningPeakEnd, eveningPeakStart)
-        + getStepsBetween(eveningPeakEnd, nightStart);
-    stepsAtNight = getStepsBetween(nightStart, nightEnd);
-  }
+	public static double computeTimeStepShare(LocalDateTime currentTime) {
+		LocalTime localTime = currentTime.toLocalTime();
+		double timeInHours = localTime.getHour() + localTime.getMinute() / 60.0 + localTime.getSecond() / 3600.0;
+		double stepHours = STEP_DURATION / 3600.0;
 
-  private static int getStepsBetween(LocalTime start, LocalTime end) {
-    int startMinutes = start.getHour() * 60 + start.getMinute();
-    int endMinutes = end.getHour() * 60 + end.getMinute();
+		double share = 0.0;
+		share += morningPeakVolume
+				* wrappedSplitGaussian(timeInHours, morningPeakTime, morningPeakSpread, morningPeakSpread);
+		share += eveningPeakVolume
+				* wrappedSplitGaussian(timeInHours, eveningPeakTime, eveningPeakSpread, eveningPeakSpread);
+		share += lunchPeakVolume * wrappedSplitGaussian(timeInHours, lunchPeakTime, lunchPeakSpread, lunchPeakSpread);
+		share += nightPeakVolume * wrappedSplitGaussian(timeInHours, nightPeakTime, nightLeftSpread, nightRightSpread);
 
-    if (endMinutes < startMinutes) {
-      // Case where the range crosses midnight
-      return ((24 * 60 - startMinutes) + endMinutes) / releaseAgentsEveryMinutes;
-    }
-    return (endMinutes - startMinutes) / 20;
-  }
+		// Add background noise across all steps evenly
+		share += backgroundVolume / 24.0;
 
-  public static double computeTimeStepShare(LocalDateTime currentTime) {
-    if (isPeakHours(currentTime)) {
-      return peakPercentage / stepsInPeakHours;
-    }
-    if (isOffPeakHours(currentTime)) {
-      return offPeakPercentage / stepsInOffPeak;
-    }
-    return nightPercentage / stepsAtNight;
-  }
+		// Multiply probability density by the step duration to get the area/share for
+		// this step
+		return share * stepHours;
+	}
 
-  public static boolean isPeakHours(LocalDateTime currentTime) {
-    LocalTime currentTimeOnly = currentTime.toLocalTime();
-    return (currentTimeOnly.isAfter(morningPeakStart) && currentTimeOnly.isBefore(morningPeakEnd))
-        || (currentTimeOnly.isAfter(eveningPeakStart) && currentTimeOnly.isBefore(eveningPeakEnd));
-  }
+	public static LocalDateTime getTime(double totalSteps) {
+		long totalMinutes = (long) (totalSteps * (TimePars.STEP_DURATION / 60)); // Convert steps to minutes based on
+																					// the stepTimeUnit
+		long totalDays = totalMinutes / (24 * 60); // Calculate total days
+		long remainingMinutes = totalMinutes % (24 * 60); // Calculate remaining minutes in the current day
 
-  public static boolean isOffPeakHours(LocalDateTime currentTime) {
-    LocalTime currentTimeOnly = currentTime.toLocalTime();
-    return (currentTimeOnly.isAfter(nightEnd) && currentTimeOnly.isBefore(morningPeakStart))
-        || (currentTimeOnly.isAfter(morningPeakEnd)
-            && currentTimeOnly.isBefore(TimePars.eveningPeakStart))
-        || currentTimeOnly.isAfter(eveningPeakEnd) || currentTimeOnly.isBefore(nightStart);
-  }
+		long hours = remainingMinutes / 60; // Convert remaining minutes to hours
+		long minutes = remainingMinutes % 60; // Calculate remaining minutes
 
-  public static LocalDateTime getTime(double totalSteps) {
-    long totalMinutes = (long) (totalSteps * (TimePars.STEP_DURATION / 60)); // Convert steps to
-                                                                             // minutes based on
-                                                                             // the stepTimeUnit
-    long totalDays = totalMinutes / (24 * 60); // Calculate total days
-    long remainingMinutes = totalMinutes % (24 * 60); // Calculate remaining minutes in the current
-                                                      // day
-
-    long hours = remainingMinutes / 60; // Convert remaining minutes to hours
-    long minutes = remainingMinutes % 60; // Calculate remaining minutes
-
-    // Return date and time starting from day 0 at 00:00
-    return LocalDateTime.of(1970, 1, 1, 0, 0).plusDays(totalDays).plusHours(hours)
-        .plusMinutes(minutes);
-  }
+		// Return date and time starting from day 0 at 00:00
+		return LocalDateTime.of(1970, 1, 1, 0, 0).plusDays(totalDays).plusHours(hours).plusMinutes(minutes);
+	}
 }

--- a/src/main/java/pedsim/core/routing/elements/LandmarkNavigation.java
+++ b/src/main/java/pedsim/core/routing/elements/LandmarkNavigation.java
@@ -38,7 +38,12 @@ public class LandmarkNavigation {
 	private static final double DISTANCE_GAIN_WEIGHT_REGION = 0.50;
 
 	protected void idntifyAgentLocalLandmarks() {
-
+		
+		// Use local landmarks only when the agent's heuristics are available
+		// and local-landmark-based navigation is actually active for this agent.
+		if (agent == null || agent.getHeuristics() == null || !agent.getProperties().isUsingLocalLandmarks()) {
+			return;
+		}
 		double localLandmarkThreshold = agent.getHeuristics().getLocalLandmarksThreshold();
 		agent.getCognitiveMap().findKnownLocalLandmarks(localLandmarkThreshold);
 	}


### PR DESCRIPTION
Adopt Gaussian-based time-of-day profile in TimePars
- Replace the old peak/off-peak threshold logic with a split-Gaussian mixture over morning, lunch, evening, and night peaks plus a background level.
- Keep existing interfaces (computeTimeStepShare, getTime, STEP_DURATION, simulationDurationInSteps) so the rest of the engine continues to work unchanged.
- Drive agent release from the new profile
- AgentReleaseManager now uses the updated TimePars.computeTimeStepShare to decide how many meters (and thus how many agents) to allocate per step, improving temporal realism of activity.
- Log agent releases to CSV for validation and plotting
- For each simulation day, write output/agent_release_day_<DAY>.csv with columns step, datetime, meters_to_allocate, meters_adjusted, agents_released.
